### PR TITLE
Update version to 2.0.1-0 and add new Niconico videos

### DIFF
--- a/argoCD/deployment.yaml
+++ b/argoCD/deployment.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
         - name: app
-          image: localhost:32000/arane-site:2.0.0
+          image: localhost:32000/arane-site:2.0.1-0
           ports:
             - containerPort: 3000
           resources:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "next-website",
-  "version": "2.0.0",
+  "version": "2.0.1-0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "next-website",
-      "version": "2.0.0",
+      "version": "2.0.1-0",
       "dependencies": {
         "@next/third-parties": "^15.0.0-rc.0",
         "next": "14.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-website",
-  "version": "2.0.0",
+  "version": "2.0.1-0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -86,7 +86,10 @@ export default function Home() {
               配布動画
             </ruby>
           </h2>
-          <Niconico id="sm43893594" width={640} height={360}></Niconico>
+          <div className="flex flex-row space-x-2">
+            <Niconico id="sm43893594" width={640} height={360}></Niconico>
+            <Niconico id="sm44014847" width={640} height={360}></Niconico>
+          </div>
         </section>
       </main>
     </>


### PR DESCRIPTION
This pull request includes changes to update the version of the `next-website` package to `2.0.1-0`. Additionally, two new Niconico videos with IDs `sm43893594` and `sm44014847` have been added to the website.