### PR TITLE
Update registry and enable TLS for development environment

### DIFF
--- a/argoCD/deployment.yaml
+++ b/argoCD/deployment.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
         - name: app
-          image: localhost:32000/arane-site:4.2.1
+          image: node08.k8s.unipro.infra:32000/arane-site:4.2.1
           ports:
             - containerPort: 3000
           resources:

--- a/argoCD/deployment.yaml
+++ b/argoCD/deployment.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
         - name: app
-          image: node08.k8s.unipro.infra:32000/arane-site:4.2.1
+          image: registry.uniproject-tech.net/arane-site:4.2.1
           ports:
             - containerPort: 3000
           resources:

--- a/argoCD/ingress.yaml
+++ b/argoCD/ingress.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   ingressClassName: nginx
   rules:
-  - host: arane.uniproject-tech.net
+  - host: arane-dev.uniproject-tech.net
     http:
       paths:
       - path: /
@@ -19,7 +19,7 @@ spec:
             name: ramura-site
             port:
               number: 80
-  tls:
-  - hosts:
-    - arane.uniproject-tech.net
-    secretName: arane-site-tls
+  #tls:
+  #- hosts:
+  #  - arane.uniproject-tech.net
+  #  secretName: arane-site-tls

--- a/argoCD/ingress.yaml
+++ b/argoCD/ingress.yaml
@@ -19,7 +19,7 @@ spec:
             name: ramura-site
             port:
               number: 80
-  #tls:
-  #- hosts:
-  #  - arane.uniproject-tech.net
-  #  secretName: arane-site-tls
+  tls:
+  - hosts:
+    - arane-dev.uniproject-tech.net
+    secretName: arane-site-tls


### PR DESCRIPTION
Change the image registry and update the ingress host for the development environment, while enabling TLS for secure connections.