### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-tag.yaml
+++ b/.github/workflows/docker-tag.yaml
@@ -1,4 +1,6 @@
 name: Docker Build and Push
+permissions:
+  contents: read
 on:
   push:
     tags:


### PR DESCRIPTION
Potential fix for [https://github.com/UniPro-tech/ramura-utau-site/security/code-scanning/9](https://github.com/UniPro-tech/ramura-utau-site/security/code-scanning/9)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the least privileges required. Based on the workflow's operations, it primarily interacts with the repository contents and Docker-related actions. Therefore, we will set `contents: read` as the minimal permission. If additional permissions are required for specific steps, they can be added later.

The `permissions` block will be added at the root level of the workflow, ensuring it applies to all jobs unless overridden by job-specific `permissions`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
